### PR TITLE
Fit SRFI 175 tests into Gambit's native test framework

### DIFF
--- a/srfi/175/175.scm
+++ b/srfi/175/175.scm
@@ -123,11 +123,9 @@
       (or (and (fx<= #x40 x #x5f) (fx- x #x40))
           (and (fx= x #x3f) #x7f))))
 
-(define (ascii-mirror-bracket char)
-  (if (fixnum? char)
-      (let ((char (ascii-mirror-bracket (integer->char char))))
-        (and char (char->integer char)))
-      (case char
+(define (ascii-mirror-bracket x)
+  (if (char? x)
+      (case x
         ((#\() #\))
         ((#\)) #\()
         ((#\[) #\])
@@ -136,7 +134,9 @@
         ((#\}) #\{)
         ((#\<) #\>)
         ((#\>) #\<)
-        (else #f))))
+        (else #f))
+      (let ((x (ascii-mirror-bracket (integer->char x))))
+        (and x (char->integer x)))))
 
 (define (ascii-ci-cmp char1 char2)
   (let ((cc1 (ensure-int char1))

--- a/srfi/175/test.scm
+++ b/srfi/175/test.scm
@@ -1,19 +1,10 @@
 ;; Copyright 2019 Lassi Kortela
 ;; SPDX-License-Identifier: MIT
 
-(import (scheme base) (scheme file) (scheme read) (scheme write) (srfi 175))
+(import (srfi 175))
+(import (_test))
 
-(define-syntax want
-  (syntax-rules ()
-    ((_ right-answer (proc args ...))
-     (unless (equal? right-answer (proc args ...))
-       (display "Failed: wanted ")
-       (write right-answer)
-       (display " but got ")
-       (write (proc args ...))
-       (display " from ")
-       (display '(proc args ...))
-       (newline)))))
+(define-syntax want (syntax-rules () ((_ x y) (check-equal? x y))))
 
 (want #f (ascii-codepoint? -1))
 (want #t (ascii-codepoint? 0))


### PR DESCRIPTION
I made a simple conversion where the sample implementation's tests now use `check-equal?` instead of a custom test runner. `check-equal?` seems to be found, but `gsi . srfi/175/test` says:

```
*** ERROR IN "srfi/175/test.scm"@4.47 -- Unbound variable: _test#passed-test```